### PR TITLE
Fix-bug: the prototype dropdown list flashes past

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The dependencies are the Bootstrap stylesheet(CSS or LESS).  Include it and then
 
 Then just activate the plugin on a normal select box(suggest having a blank option first):
 
-    <select class="combobox">
+    <select class="combobox form-control hidden">
       <option></option>
       <option value="PA">Pennsylvania</option>
       <option value="CT">Connecticut</option>

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -49,7 +49,6 @@
   , setup: function () {
       var combobox = $(this.template());
       this.$source.before(combobox);
-      this.$source.hide();
       return combobox;
     }
 
@@ -107,7 +106,7 @@
     this.$element.attr('required', this.$source.attr('required'))
     this.$element.attr('rel', this.$source.attr('rel'))
     this.$element.attr('title', this.$source.attr('title'))
-    this.$element.attr('class', this.$source.attr('class'))
+    this.$element.attr('class', this.$source.attr('class')).removeClass('hidden');
     this.$element.attr('tabindex', this.$source.attr('tabindex'))
     this.$source.removeAttr('tabindex')
     if (this.$source.attr('disabled')!==undefined)


### PR DESCRIPTION
We know the prototype dropdown list appears in the same position of target combobox is not a good user experience, although it happens in the blink of an eye. We could checkout it out on https://jsfiddle.net/dabeng/8k9m6qg5/. 

In other words, it's always not fast enough to use js code snippets to hide elements because users can see the elements early.
