### PR TITLE
chore(event): allow clicking dropdown menu item event to bubble

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-combobox",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "homepage": "https://github.com/danielfarrell/bootstrap-combobox",
   "authors": [
     "Daniel Farrell <danielfarrell76@gmail.com>",

--- a/js/bootstrap-combobox.js
+++ b/js/bootstrap-combobox.js
@@ -422,7 +422,6 @@
     }
 
   , click: function (e) {
-      e.stopPropagation();
       e.preventDefault();
       this.select();
       this.$element.focus();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly-bootstrap-combobox",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": "Red Hat",
   "license": "Apache-2.0",
   "description": "This is a fork of danielfarrell/bootstrap-combobox v1.1.6 used for NPM packaging",


### PR DESCRIPTION
Without this bug-fix, the save button adjacent to department combobox on [inline-edit form](https://rawgit.com/dabeng/patternfly/inline-edit2-dist/dist/tests/inline-edit.html) will not be enabled even when users choose one new value by click drop-down menu item.

More specifically, the following [event handler code snippets](https://github.com/patternfly/patternfly/pull/979/files#diff-34ebdcb9d4654815bc2fccddc8809b6aR198) within inline-edit PR will make sense with the help of this bug-fix:
```js
    $('.pf-inline-edit-form').find('.combobox-container')
    .on('click', '[data-value]', function () {
      monitorValueChange($(this).closest('.pf-inline-edit-form'));
    });
```