### PR TITLE
Fixes a width issue in Firefix with the dropdown options

### DIFF
--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -19,6 +19,7 @@
 }
 .typeahead-long {
   max-height: 300px;
+  width: 100%;
   overflow-y: auto;
 }
 .control-group.error .combobox-container .add-on {

--- a/less/combobox.less
+++ b/less/combobox.less
@@ -23,6 +23,7 @@
 
 .typeahead-long {
   max-height: 300px;
+  width: 100%;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
I noticed that in Firefox at least, the width of the dropdown wasn't very wide:

![screenshot at 2018-04-12 13 06 51](https://user-images.githubusercontent.com/5341149/38676295-7497b8ac-3e52-11e8-9e63-27c14e99ffc1.png)

This fixes that issue, making the options the full width.

PS: Thanks for the nice work on this!